### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you just wish to use the publicly available Lambda layers you will need the A
 
 #### v2.0.0-python
 
-See the [GeoLambda Python README](python/README.md). The Python Lambda Layer includes the libraries `numpy`, `rasterio`, `GDAL`, `pyproj`, and `shapely`.
+See the [GeoLambda Python README](python/README.md). The Python Lambda Layer includes the libraries `numpy`, `rasterio`, `GDAL`, `pyproj`, and `shapely`. This is an addition to the standard GeoLambda layer; if you wish to use GeoLambda-Python, both layers must be included.
 
 | Region | ARN |
 | ------ | --- |
@@ -56,7 +56,7 @@ See the [GeoLambda Python README](python/README.md). The Python Lambda Layer inc
 
 #### v1.2.0-python
 
-See the [GeoLambda Python README](python/README.md). The Python Lambda Layer includes the libraries `numpy`, `rasterio`, `GDAL`, `pyproj`, and `shapely`.
+See the [GeoLambda Python README](python/README.md). The Python Lambda Layer includes the libraries `numpy`, `rasterio`, `GDAL`, `pyproj`, and `shapely`. This is an addition to the standard GeoLambda layer; if you wish to use GeoLambda-Python, both layers must be included.
 
 | Region | ARN |
 | ------ | --- |


### PR DESCRIPTION
Include sentences mentioning that to use `geolambda-python`, both `geolambda` and geolambda python must be included. This was hard to figure out, until I saw this issue: https://github.com/developmentseed/geolambda/issues/54#issuecomment-480048288