### PR TITLE
add --symlinks flag to zip command

### DIFF
--- a/bin/package.sh
+++ b/bin/package.sh
@@ -21,4 +21,4 @@ rsync -ax $PREFIX/share/proj $DEPLOY_DIR/share/
 
 # zip up deploy package
 cd $DEPLOY_DIR
-zip -ruq ../lambda-deploy.zip ./
+zip -ruq --symlinks ../lambda-deploy.zip ./


### PR DESCRIPTION
Thanks for putting this project together, it is a great building block!

While trying to build a `geopandas` layer on top of this, I was hitting AWS's 250 mb unzipped size limit. While looking for places to trim some fat, I noticed that in the `geolambda` base layer, under `lib`, the various `.so.*` library files were actually duplicates instead of symlinks. By adding `--symlinks` to the `zip` command in the shell script, the symlinks are preserved, and I was able to shrink the unzipped base layer size from around 90 mb to 36 mb. `geopandas` (as well as the large `pandas` and `fiona` deps) now just barely fits in with the rest of the `geolambda` python layer.

I have done some very modest testing with the new base layer and it doesn't seem that AWS Lambda has any problems with the symlinks and everything works the same as before, but more testing may be required.