### PR TITLE
Ensure rsync available in image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 lambda-deploy.zip
 lambda-layer-deploy.zip
 .DS_Store
+lambda/*
+python/lambda/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -212,6 +212,10 @@ RUN \
     ./config shared --prefix=${PREFIX}/openssl --openssldir=${PREFIX}/openssl; \
     make depend; make install; cd ..; rm -rf openssl
 
+# rsync is required by bin/package.sh, so install it here
+RUN \
+    yum install -y rsync
+
 
 # Copy shell scripts and config files over
 COPY bin/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	./build-and-test.sh
+
+clean:
+	-rm -rf lambda/
+	-rm lambda-deploy.zip
+	-rm python/lambda-deploy.zip
+	git ls-files -o python/lambda | while read f; do rm -- "$$f"; done

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 VERSION=$(cat VERSION)
 
 docker build . -t developmentseed/geolambda:${VERSION}

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -10,4 +10,4 @@ cd python
 docker build . --build-arg VERSION=${VERSION} -t developmentseed/geolambda:${VERSION}-python
 docker run -v ${PWD}:/home/geolambda -t developmentseed/geolambda:${VERSION}-python package-python.sh
 
-docker run --rm -e PROJ_LIB=/opt/share/proj -v ${PWD}/lambda:/var/task -v ${PWD}/../lambda:/opt lambci/lambda:python3.7 lambda_function.lambda_handler '{}'
+docker run --rm -v ${PWD}/lambda:/var/task -v ${PWD}/../lambda:/opt lambci/lambda:python3.7 lambda_function.lambda_handler '{}'

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -10,4 +10,4 @@ cd python
 docker build . --build-arg VERSION=${VERSION} -t developmentseed/geolambda:${VERSION}-python
 docker run -v ${PWD}:/home/geolambda -t developmentseed/geolambda:${VERSION}-python package-python.sh
 
-docker run --rm -v ${PWD}/lambda:/var/task -v ${PWD}/../lambda:/opt lambci/lambda:python3.7 lambda_function.lambda_handler '{}'
+docker run --rm -e PROJ_LIB=/opt/share/proj -v ${PWD}/lambda:/var/task -v ${PWD}/../lambda:/opt lambci/lambda:python3.7 lambda_function.lambda_handler '{}'

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -2,8 +2,9 @@
 set -e
 VERSION=$(cat VERSION)
 
+INTERACTIVE=$(if test -t 0; then echo -i; fi)
 docker build . -t developmentseed/geolambda:${VERSION}
-docker run --rm -v $PWD:/home/geolambda -it developmentseed/geolambda:${VERSION} package.sh
+docker run --rm -v $PWD:/home/geolambda ${INTERACTIVE} -t developmentseed/geolambda:${VERSION} package.sh
 
 cd python
 docker build . --build-arg VERSION=${VERSION} -t developmentseed/geolambda:${VERSION}-python


### PR DESCRIPTION
I recently checked out @ 2.0.0 and attempted to build it, but found the rsync step was failing because of a missing dependency in the image.

This likely would not have caused a visible issue (at least as far as the build artefacts were concerned) if the build was performed in a dirty environment in which rsync copied files had already been copied, however, it did cause issues in my (clean) environment where there were no such artefacts available. The issue was also apparent in the build messages themselves which showed that rsync was missing. 

So, I fixed the Dockerfile to add the rsync dependency to the image.

I have also added a Makefile with a clean target to allow a pristine environment to be restored easily and idiomatically.

The code in this PR is built on the 2.0.0 tag but merges cleanly with master.

PR amended with commits to:

- add .gitignore rules for the build products (mainly for cases where this module is used as a submodule)
- fail the build in case any command fails
- disable the docker run -i option in non-interactive environments
- configure PROJ_LIB variable to reduce noise during test lambda execution

The final 2 commits are git foo to permit the same branch to be merged (at different points) with a branch derived from 2.0.0 or a branch derived from origin/master and both merges will succeed without conflict as will any merged derived from each.

I am, of course, happy to restructure the PR into a master only PR if this too complicated for others to follow, but until I get feedback I will leave it as is, is as this is the format I prefer to maintain it in.

For others: if you want these fixes on 2.0.0 variant, merge 
c27bf0a. If you want a master variant, merge 
7d8e184 (or 1c8d1f6)